### PR TITLE
fix(ping): ensure ping returns immediately

### DIFF
--- a/src/modules/ping/ping.streams.test.ts
+++ b/src/modules/ping/ping.streams.test.ts
@@ -31,7 +31,7 @@ describe('Ping Streams', () => {
       }
 
       const expected$ = m.cold('--a-b-c', expectedEvent)
-      const value$ = createPingStream(1000, 'YYYY-MM-DD', m.scheduler)
+      const value$ = createPingStream(1000, () => 'YYYY-MM-DD', m.scheduler)
 
       m.expect(value$).toBeObservable(expected$)
     })
@@ -51,11 +51,11 @@ describe('Ping Streams', () => {
       }
 
       // eslint-disable-next-line prettier/prettier
-      const expected$ = m.hot('^x----x----x----x----x----x', pingEvents)
+      const expected$ = m.hot('xx----x----x----x----x----x', pingEvents)
       const value$ = createDebouncedPingStream(
         100,
         500,
-        'YYYY-MM-DD',
+        () => 'YYYY-MM-DD',
         m.scheduler
       )
 

--- a/src/modules/ping/ping.streams.ts
+++ b/src/modules/ping/ping.streams.ts
@@ -2,19 +2,20 @@ import { Observable } from 'rxjs/internal/Observable'
 import { map, throttleTime } from 'rxjs/operators'
 import { TestScheduler } from 'rxjs/testing'
 import { interval } from 'rxjs/internal/observable/interval'
+import { of, merge } from 'rxjs'
 
 import { Ping } from '../../generated/graphql'
 
 const ONE_MINUTE_IN_MS = 1000 * 60
 const createPingStream = (
   period: number = ONE_MINUTE_IN_MS,
-  date: string = new Date().toUTCString(),
+  createDate: () => string = () => new Date().toUTCString(),
   scheduler?: TestScheduler
 ): Observable<Ping> => {
   return interval(period, scheduler).pipe(
     map<number, Ping>(() => ({
       __typename: 'Ping',
-      date,
+      date: createDate(),
       message: 'OK',
     }))
   )
@@ -23,16 +24,19 @@ const createPingStream = (
 const createDebouncedPingStream = (
   period: number,
   throttleDuration: number = ONE_MINUTE_IN_MS,
-  date: string = new Date().toUTCString(),
+  createDate: () => string = () => new Date().toUTCString(),
   scheduler?: TestScheduler
 ): Observable<Ping> =>
-  interval(period, scheduler).pipe(
-    throttleTime(throttleDuration, scheduler),
-    map<number, Ping>(() => ({
-      __typename: 'Ping',
-      date,
-      message: 'OK',
-    }))
+  merge(
+    of({ __typename: 'Ping', date: createDate(), message: 'OK' }),
+    interval(period, scheduler).pipe(
+      throttleTime(throttleDuration, scheduler),
+      map<number, Ping>(() => ({
+        __typename: 'Ping',
+        date: createDate(),
+        message: 'OK',
+      }))
+    )
   )
 
 export { createPingStream, createDebouncedPingStream, ONE_MINUTE_IN_MS }


### PR DESCRIPTION
- when pings are set to a big interval, the consumer would have to wait too long for the first event,
  instead, we send an event immediately to acknowledge the subscription.