### PR TITLE
fix(auth): remove from context

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { gql, IResolvers } from 'apollo-server-express'
+import { AuthenticationError, gql, IResolvers } from 'apollo-server-express'
 import {
   ApolloServerExpressConfig,
   ExpressContext,
@@ -28,14 +28,14 @@ const appConfig: ApolloServerExpressConfig = {
       )
       if (error.type !== ErrorType.NONE) {
         errorHandler.handleError(error)
-        throw new Error(error.type)
+        throw new AuthenticationError(error.type)
       }
 
       const auth = await createWebSocketAuthContext(context)
 
       if (auth.error.type !== ErrorType.NONE) {
         errorHandler.handleError(auth.error)
-        throw new Error(auth.error.type)
+        throw new AuthenticationError(auth.error.type)
       }
     },
   },

--- a/src/context/auth/createWebSocketAuthContext.ts
+++ b/src/context/auth/createWebSocketAuthContext.ts
@@ -17,10 +17,15 @@ const createWebSocketAuthContext = async (
     audience,
     algorithms: ['RS256'],
     publicKey: createPublicKeyHandler(jsonWebKeySet.expressJwtSecret, {
-      cache: true,
-      rateLimit: true,
-      jwksRequestsPerMinute: 5,
       jwksUri: uri,
+      jwksRequestsPerMinute: 30,
+
+      rateLimit: true,
+      timeout: 30000, // 30s
+
+      cache: true,
+      cacheMaxEntries: 5, // Default value
+      cacheMaxAge: 1800000, // 30m
     }),
   })(context)
 }

--- a/src/context/createContext.ts
+++ b/src/context/createContext.ts
@@ -1,37 +1,16 @@
 import pino from 'pino'
-import { ExpressContext } from 'apollo-server-express/dist/ApolloServer'
-import jsonWebKeySet from 'jwks-rsa'
 
-import getEnv from '../env'
 import { logger } from '../logger'
 
-import createAuthContext, { ContextAuth } from './auth/createAuthContext'
-import createPublicKeyHandler from './auth/createPublicKeyHandler'
 import { errorHandler, ErrorHandler } from './error/errorHandler'
 
 interface ContextApp {
-  auth: ContextAuth
   logger: pino.Logger
   error: ErrorHandler
 }
 
-const createContext = async (context: ExpressContext): Promise<ContextApp> => {
-  const {
-    auth0: { audience, uri },
-  } = getEnv()
-  const auth = await createAuthContext({
-    audience,
-    algorithms: ['RS256'],
-    publicKey: createPublicKeyHandler(jsonWebKeySet.expressJwtSecret, {
-      cache: true,
-      rateLimit: true,
-      jwksRequestsPerMinute: 5,
-      jwksUri: uri,
-    }),
-  })(context)
-
+const createContext = async (): Promise<ContextApp> => {
   return {
-    auth,
     logger,
     error: errorHandler,
   }


### PR DESCRIPTION
The auth context needs to be revisited.
we have enabled auth in the web socket, which returns a connection arg in the context function.
since we didn't account for it (didn't know it existed) the contract is broken as it isnt (req, res) as previously thought

The context function needs to account for:

```
interface ExpressContext {
  req: express.Request;
  res: express.Response;
  connection?: ExecutionParams;
}
```
