### PR TITLE
fix(auth | env): error if no keys are provided

### DIFF
--- a/src/auth/Auth.test.ts
+++ b/src/auth/Auth.test.ts
@@ -38,7 +38,7 @@ describe('AUTH', () => {
     })
 
     // @ts-ignore
-    new Auth(void 0, void 0, errorHandler)
+    expect(() => new Auth(void 0, void 0, errorHandler)).toThrow()
   })
 
   it('should should retrieve keys', async () => {

--- a/src/auth/Auth.ts
+++ b/src/auth/Auth.ts
@@ -19,13 +19,12 @@ class Auth {
     errorHandler: ErrorHandler
   ) {
     if (!signingKeys || !signingKeysUri) {
-      errorHandler.handleError({
+      throw errorHandler.handleError({
         type: ErrorType.AUTH_CONSTRUCTOR,
         hint: 'Failed to provide signingKeys or signingKeysUri',
         source: new Error(),
       })
     }
-
     this.errorHandler = errorHandler
     this.keys = this.createKeyStore(signingKeys)
   }

--- a/src/env.ts
+++ b/src/env.ts
@@ -8,7 +8,10 @@ import memoise from './utils/memoise'
  * process.env is made available through
  * webpack externals
  */
-const processEnv = process.env || require('processEnv')
+const processEnv = Object.getOwnPropertyNames(process.env).length
+  ? process.env
+  : require('processEnv')
+
 const PATH_ROOT = path.resolve(__dirname, '..')
 
 enum EnvVar {


### PR DESCRIPTION
- checks for process env values, otherwise resolve to shim as specified in https://blog.freemiumpn.com/docs/developer/how-to/web/runtime-configs-with-webpack-and-docker-v2
